### PR TITLE
Replaced config property with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,12 @@ use lithium\util\Inflector;
 
 class Slug extends \li3_behaviors\data\model\Behavior {
 
-	/**
-	 * Default field names to slug
-	 *
-	 * @var array
-	 */
-	protected $_defaults = array(
-		'fields' => ['label' => 'slug']
-	);
+	public function __construct(array $config = []) {
+		$defaults = [
+			'fields' => ['label' => 'slug']
+		];
+		parent::__construct($config + $defaults);
+	}
 
 	protected function _init() {
 		parent::_init();

--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ class Slug extends \li3_behaviors\data\model\Behavior {
 		}
 	}
 
-	protected function _slug() {
+	protected function _slug($params) {
 		extract($this->_config);
 		foreach ($fields as $from => $to) {
 			if (isset($params['data'][$from])) {
 				$params['data'][$to] = Inflector::slug($params['data'][$from]);
 			}
 		}
+		return $params;
 	}
 }
 ?>

--- a/data/model/Behavior.php
+++ b/data/model/Behavior.php
@@ -11,13 +11,6 @@ namespace li3_behaviors\data\model;
 class Behavior extends \lithium\core\Object {
 
 	/**
-	 * Holding the configuration array of the behavior
-	 *
-	 * @var array
-	 */
-	protected $_defaults = [];
-
-	/**
 	 * @see lithium\core\Object::_autoConfig
 	 * @var array
 	 */
@@ -29,17 +22,6 @@ class Behavior extends \lithium\core\Object {
 	 * @var string
 	 */
 	protected $_model = null;
-
-	/**
-	 * Bind
-	 *
-	 * Applies Behaviour to the Model and configures its use
-	 *
-	 * @param \lithium\data\Model $self The Model using this behaviour
-	 */
-	public function __construct($config = []) {
-		parent::__construct($config + $this->_defaults);
-	}
 
 	/**
 	 * Sets/Gets the configuration for this behavior

--- a/data/model/Behavior.php
+++ b/data/model/Behavior.php
@@ -15,12 +15,14 @@ class Behavior extends \lithium\core\Object {
 	 *
 	 * @var array
 	 */
-	protected $_config = [];
+	protected $_defaults = [];
+
 	/**
 	 * @see lithium\core\Object::_autoConfig
 	 * @var array
 	 */
-	protected $_autoConfig = ['model', 'config'];
+	protected $_autoConfig = ['model'];
+
 	/**
 	 * Hold the fully namespaced class name of the model
 	 *
@@ -36,7 +38,7 @@ class Behavior extends \lithium\core\Object {
 	 * @param \lithium\data\Model $self The Model using this behaviour
 	 */
 	public function __construct($config = []) {
-		parent::__construct($config);
+		parent::__construct($config + $this->_defaults);
 	}
 
 	/**

--- a/tests/cases/data/model/BehaviorTest.php
+++ b/tests/cases/data/model/BehaviorTest.php
@@ -13,7 +13,7 @@ use li3_behaviors\data\model\Behavior;
 class BehaviorTest extends \lithium\test\Unit {
 
 	public function testConfig() {
-		$behavior = new Behavior(['config' => ['test1' => 'value1']]);
+		$behavior = new Behavior(['test1' => 'value1']);
 		$this->assertEqual('value1', $behavior->config('test1'));
 
 		$behavior->config(['test2' => 'value2']);


### PR DESCRIPTION
With the Slug example provided in the readme the defaults has no effect. I think this is the proper way to configure the behavior object.

On the other hand config property shouldn't be overridden, according to https://github.com/UnionOfRAD/lithium/blob/master/core/Object.php#L47 
